### PR TITLE
Feat/#16: 초대코드 제한시간

### DIFF
--- a/src/main/java/gdg/travodobackend/app/travel/entity/Trip.java
+++ b/src/main/java/gdg/travodobackend/app/travel/entity/Trip.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,14 +32,23 @@ public class Trip {
 
     @OneToMany(mappedBy = "trip")
     private List<TripMember> members = new ArrayList<>();
-
-    // 초대 코드 재발급 메서드
-    public void updateInviteCode(String newCode) {
-        this.inviteCode = newCode;
-    }
+    private LocalDateTime inviteCodeExpiresAt;
 
     // 여행 상태 변경 메서드
     public void updateStatus(TripStatus status) {
         this.status = status;
     }
+
+    // 초대코드 유효성 검사
+    public boolean isInviteCodeExpired() {
+        return inviteCodeExpiresAt != null && LocalDateTime.now().isAfter(inviteCodeExpiresAt);
+    }
+
+    // 만료시간 설정 메서드
+    public void updateInviteCode(String newCode, LocalDateTime expiresAt) {
+        this.inviteCode = newCode;
+        this.inviteCodeExpiresAt = expiresAt;
+    }
+
+
 }

--- a/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
 
@@ -32,6 +33,7 @@ public class TripService {
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         String inviteCode = generateUniqueInviteCode(); // 중복 방지 코드 생성
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(5);
 
         Trip trip = Trip.builder()
                 .name(request.name())
@@ -40,6 +42,7 @@ public class TripService {
                 .endDate(request.endDate())
                 .status(TripStatus.UPCOMING)
                 .inviteCode(inviteCode)
+                .inviteCodeExpiresAt(expiresAt)
                 .build();
         tripRepository.save(trip);
 
@@ -62,7 +65,9 @@ public class TripService {
                 .orElseThrow(() -> new RuntimeException("Trip not found"));
 
         String newCode = generateUniqueInviteCode(); // 중복 방지 코드 생성
-        trip.updateInviteCode(newCode);
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(5);
+
+        trip.updateInviteCode(newCode,expiresAt);
         tripRepository.save(trip);
 
         return newCode;
@@ -73,6 +78,10 @@ public class TripService {
 
         Trip trip = tripRepository.findByInviteCode(request.inviteCode())
                 .orElseThrow(() -> new RuntimeException("Invalid invite code"));
+
+        if (trip.isInviteCodeExpired()) {
+            throw new RuntimeException("초대코드가 만료되었습니다. 새 코드를 요청하세요.");
+        }
 
         if (tripMemberRepository.existsByTripIdAndUserId(trip.getId(), userId)) {
             throw new RuntimeException("이미 참가한 여행입니다.");


### PR DESCRIPTION
# 초대코드 시간 제한(5분) 기능 구현

## 1) 초대코드 유효시간 적용
- 여행 생성 시 초대코드에 만료시간(inviteCodeExpiresAt) 설정  
- 현재시간 + 5분으로 자동 계산  
- Trip 엔티티에 만료시간 필드 추가  

---

## 2) 초대코드 만료 검증
- 여행 참가(POST `/api/trips/join`) 시 초대코드 만료 여부 검사  
- isInviteCodeExpired() 메서드로 검증  
- 만료된 코드일 경우 참가 불가 처리  
- 예외 메시지: "초대코드가 만료되었습니다. 새 코드를 요청하세요."  

---

## 3) 초대코드 재발급 기능
- POST `/api/trips/{tripId}/invite-code` 호출 시 새 초대코드 발급  
- 기존 코드와 중복되지 않도록 랜덤 생성  
- 만료시간을 다시 5분으로 초기화  
- 클라이언트에 신규 초대코드 반환  

---
