### PR TITLE
feat/#20:여행 활동,초대코드 재발급 권한 제한,PersonalItem / SharedItem Validation 보완

### DIFF
--- a/src/main/java/gdg/travodobackend/app/travel/controller/ActivityController.java
+++ b/src/main/java/gdg/travodobackend/app/travel/controller/ActivityController.java
@@ -1,0 +1,66 @@
+package gdg.travodobackend.app.travel.controller;
+
+import gdg.travodobackend.app.travel.dto.*;
+import gdg.travodobackend.app.travel.service.ActivityService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trips/{tripId}/activities")
+public class ActivityController {
+
+    private final ActivityService activityService;
+
+    // 생성
+    @PostMapping
+    public ResponseEntity<ActivityResponse> create(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long tripId,
+            @Valid @RequestBody ActivityCreateRequest request
+    ) {
+        return ResponseEntity.ok(
+                activityService.create(userId, tripId, request)
+        );
+    }
+
+    // 수정
+    @PutMapping("/{activityId}")
+    public ResponseEntity<ActivityResponse> update(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long tripId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody ActivityUpdateRequest request
+    ) {
+        return ResponseEntity.ok(
+                activityService.update(userId, tripId, activityId, request)
+        );
+    }
+
+    // 삭제
+    @DeleteMapping("/{activityId}")
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long tripId,
+            @PathVariable Long activityId
+    ) {
+        activityService.delete(userId, tripId, activityId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 상태 변경
+    @PatchMapping("/{activityId}/status")
+    public ResponseEntity<ActivityResponse> updateStatus(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long tripId,
+            @PathVariable Long activityId,
+            @Valid @RequestBody ActivityStatusUpdateRequest request
+    ) {
+        return ResponseEntity.ok(
+                activityService.updateStatus(userId, tripId, activityId, request)
+        );
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/travel/controller/PersonalItemController.java
+++ b/src/main/java/gdg/travodobackend/app/travel/controller/PersonalItemController.java
@@ -4,6 +4,7 @@ import gdg.travodobackend.app.travel.dto.PersonalItemCreateRequest;
 import gdg.travodobackend.app.travel.dto.PersonalItemResponse;
 import gdg.travodobackend.app.travel.dto.PersonalItemUpdateRequest;
 import gdg.travodobackend.app.travel.service.PersonalItemService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,25 +30,25 @@ public class PersonalItemController {
         );
     }
 
-    // 개인 준비물 생성
+    // 개인 준비물 생성 
     @PostMapping
     public ResponseEntity<PersonalItemResponse> createItem(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long tripId,
-            @RequestBody PersonalItemCreateRequest request
+            @Valid @RequestBody PersonalItemCreateRequest request
     ) {
         return ResponseEntity.ok(
                 personalItemService.createItem(userId, tripId, request)
         );
     }
 
-    // 개인 준비물 수정 (이름/체크 상태 일부만 변경하는 PATCH)
+    // 개인 준비물 수정
     @PatchMapping("/{itemId}")
     public ResponseEntity<PersonalItemResponse> updateItem(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long tripId,
             @PathVariable Long itemId,
-            @RequestBody PersonalItemUpdateRequest request
+            @Valid @RequestBody PersonalItemUpdateRequest request
     ) {
         return ResponseEntity.ok(
                 personalItemService.updateItem(userId, tripId, itemId, request)

--- a/src/main/java/gdg/travodobackend/app/travel/controller/SharedItemController.java
+++ b/src/main/java/gdg/travodobackend/app/travel/controller/SharedItemController.java
@@ -4,6 +4,7 @@ import gdg.travodobackend.app.travel.dto.SharedItemCreateRequest;
 import gdg.travodobackend.app.travel.dto.SharedItemResponse;
 import gdg.travodobackend.app.travel.dto.SharedItemUpdateRequest;
 import gdg.travodobackend.app.travel.service.SharedItemService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,7 +20,6 @@ public class SharedItemController {
     private final SharedItemService sharedItemService;
 
     // 공동 준비물 전체 조회
-
     @GetMapping
     public ResponseEntity<List<SharedItemResponse>> getItems(
             @AuthenticationPrincipal Long userId,
@@ -31,25 +31,23 @@ public class SharedItemController {
     }
 
     // 공동 준비물 생성
-
     @PostMapping
     public ResponseEntity<SharedItemResponse> createItem(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long tripId,
-            @RequestBody SharedItemCreateRequest request
+            @Valid @RequestBody SharedItemCreateRequest request
     ) {
         return ResponseEntity.status(201)
                 .body(sharedItemService.createItem(userId, tripId, request));
     }
 
-    // 공동 준비물 수정 (이름 / 체크)
-
+    // 공동 준비물 수정
     @PatchMapping("/{itemId}")
     public ResponseEntity<SharedItemResponse> updateItem(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long tripId,
             @PathVariable Long itemId,
-            @RequestBody SharedItemUpdateRequest request
+            @Valid @RequestBody SharedItemUpdateRequest request
     ) {
         return ResponseEntity.ok(
                 sharedItemService.updateItem(userId, tripId, itemId, request)
@@ -57,7 +55,6 @@ public class SharedItemController {
     }
 
     // 담당자 지정
-
     @PatchMapping("/{itemId}/assign")
     public ResponseEntity<SharedItemResponse> assignItem(
             @AuthenticationPrincipal Long userId,
@@ -70,7 +67,6 @@ public class SharedItemController {
     }
 
     // 담당자 해제
-
     @PatchMapping("/{itemId}/unassign")
     public ResponseEntity<SharedItemResponse> unassignItem(
             @AuthenticationPrincipal Long userId,
@@ -83,7 +79,6 @@ public class SharedItemController {
     }
 
     // 공동 준비물 삭제
-
     @DeleteMapping("/{itemId}")
     public ResponseEntity<Void> deleteItem(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/gdg/travodobackend/app/travel/controller/TripController.java
+++ b/src/main/java/gdg/travodobackend/app/travel/controller/TripController.java
@@ -39,9 +39,10 @@ public class TripController {
     // 초대 코드 재발급 (POST /trips/{tripId}/invite-code)
     @PostMapping("/{tripId}/invite-code")
     public ResponseEntity<Map<String, String>> regenerateInviteCode(
+            @AuthenticationPrincipal Long userId,
             @PathVariable Long tripId
     ) {
-        String code = tripService.regenerateInviteCode(tripId);
+        String code = tripService.regenerateInviteCode(userId, tripId);
         return ResponseEntity.ok(Map.of("inviteCode", code));
     }
 

--- a/src/main/java/gdg/travodobackend/app/travel/dto/ActivityCreateRequest.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/ActivityCreateRequest.java
@@ -1,0 +1,17 @@
+package gdg.travodobackend.app.travel.dto;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record ActivityCreateRequest(
+
+        @NotBlank(message = "활동 제목은 필수입니다.")
+        String title,
+
+        @NotNull(message = "활동 시간은 필수입니다.")
+        @Future(message = "활동 시간은 미래여야 합니다.")
+        LocalDateTime time
+) {}

--- a/src/main/java/gdg/travodobackend/app/travel/dto/ActivityResponse.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/ActivityResponse.java
@@ -1,0 +1,21 @@
+package gdg.travodobackend.app.travel.dto;
+
+import gdg.travodobackend.app.travel.entity.Activity;
+
+import java.time.LocalDateTime;
+
+public record ActivityResponse(
+        Long id,
+        String title,
+        LocalDateTime time,
+        String status
+) {
+    public static ActivityResponse from(Activity activity) {
+        return new ActivityResponse(
+                activity.getId(),
+                activity.getTitle(),
+                activity.getTime(),
+                activity.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/travel/dto/ActivityStatusUpdateRequest.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/ActivityStatusUpdateRequest.java
@@ -1,0 +1,8 @@
+package gdg.travodobackend.app.travel.dto;
+
+import gdg.travodobackend.app.travel.entity.ActivityStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record ActivityStatusUpdateRequest(
+        @NotNull ActivityStatus status
+) {}

--- a/src/main/java/gdg/travodobackend/app/travel/dto/ActivityUpdateRequest.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/ActivityUpdateRequest.java
@@ -1,0 +1,17 @@
+package gdg.travodobackend.app.travel.dto;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record ActivityUpdateRequest(
+
+        @NotBlank(message = "활동 제목은 필수입니다.")
+        String title,
+
+        @NotNull(message = "활동 시간은 필수입니다.")
+        @Future(message = "활동 시간은 미래여야 합니다.")
+        LocalDateTime time
+) {}

--- a/src/main/java/gdg/travodobackend/app/travel/dto/PersonalItemCreateRequest.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/PersonalItemCreateRequest.java
@@ -1,4 +1,9 @@
 package gdg.travodobackend.app.travel.dto;
 
-public record PersonalItemCreateRequest(String name) {}
+import jakarta.validation.constraints.NotBlank;
 
+public record PersonalItemCreateRequest(
+
+        @NotBlank(message = "개인 준비물 이름은 필수입니다.")
+        String name
+) {}

--- a/src/main/java/gdg/travodobackend/app/travel/dto/PersonalItemUpdateRequest.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/PersonalItemUpdateRequest.java
@@ -7,4 +7,3 @@ public record PersonalItemUpdateRequest(
         String name,
         Boolean checked   // boolean이 아니라 Boolean이어야 null 체크 가능
 ) {}
-

--- a/src/main/java/gdg/travodobackend/app/travel/dto/SharedItemCreateRequest.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/SharedItemCreateRequest.java
@@ -1,3 +1,15 @@
 package gdg.travodobackend.app.travel.dto;
 
-public record SharedItemCreateRequest(String name) {}
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record SharedItemCreateRequest(
+
+        @NotBlank(message = "공동 준비물 이름은 필수입니다.")
+        String name,
+
+        @NotNull(message = "수량은 필수입니다.")
+        @Positive(message = "수량은 1 이상이어야 합니다.")
+        Integer quantity
+) {}

--- a/src/main/java/gdg/travodobackend/app/travel/entity/Activity.java
+++ b/src/main/java/gdg/travodobackend/app/travel/entity/Activity.java
@@ -1,0 +1,36 @@
+package gdg.travodobackend.app.travel.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Activity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Trip trip;
+
+    private String title;
+
+    private LocalDateTime time;
+
+    @Enumerated(EnumType.STRING)
+    private ActivityStatus status;
+
+    public void update(String title, LocalDateTime time) {
+        this.title = title;
+        this.time = time;
+    }
+
+    public void updateStatus(ActivityStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/travel/entity/ActivityStatus.java
+++ b/src/main/java/gdg/travodobackend/app/travel/entity/ActivityStatus.java
@@ -1,0 +1,6 @@
+package gdg.travodobackend.app.travel.entity;
+
+public enum ActivityStatus {
+    PENDING,
+    DONE
+}

--- a/src/main/java/gdg/travodobackend/app/travel/repository/ActivityRepository.java
+++ b/src/main/java/gdg/travodobackend/app/travel/repository/ActivityRepository.java
@@ -1,0 +1,11 @@
+package gdg.travodobackend.app.travel.repository;
+
+import gdg.travodobackend.app.travel.entity.Activity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+
+    Optional<Activity> findByIdAndTripId(Long id, Long tripId);
+}

--- a/src/main/java/gdg/travodobackend/app/travel/repository/TripMemberRepository.java
+++ b/src/main/java/gdg/travodobackend/app/travel/repository/TripMemberRepository.java
@@ -3,6 +3,11 @@ package gdg.travodobackend.app.travel.repository;
 import gdg.travodobackend.app.travel.entity.TripMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TripMemberRepository extends JpaRepository<TripMember, Long> {
+
     boolean existsByTripIdAndUserId(Long tripId, Long userId);
+
+    Optional<TripMember> findByTripIdAndUserId(Long tripId, Long userId);
 }

--- a/src/main/java/gdg/travodobackend/app/travel/service/ActivityService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/ActivityService.java
@@ -1,0 +1,82 @@
+package gdg.travodobackend.app.travel.service;
+
+import gdg.travodobackend.app.travel.dto.*;
+import gdg.travodobackend.app.travel.entity.*;
+import gdg.travodobackend.app.travel.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ActivityService {
+
+    private final ActivityRepository activityRepository;
+    private final TripRepository tripRepository;
+    private final TripMemberRepository tripMemberRepository;
+
+    private void validateTripMember(Long tripId, Long userId) {
+        if (!tripMemberRepository.existsByTripIdAndUserId(tripId, userId)) {
+            throw new RuntimeException("여행 멤버만 활동을 관리할 수 있습니다.");
+        }
+    }
+
+    public ActivityResponse create(
+            Long userId, Long tripId, ActivityCreateRequest request
+    ) {
+        validateTripMember(tripId, userId);
+
+        Trip trip = tripRepository.findById(tripId)
+                .orElseThrow(() -> new RuntimeException("여행을 찾을 수 없습니다."));
+
+        Activity activity = Activity.builder()
+                .trip(trip)
+                .title(request.title())
+                .time(request.time())
+                .status(ActivityStatus.PENDING)
+                .build();
+
+        activityRepository.save(activity);
+
+        return ActivityResponse.from(activity);
+    }
+
+    public ActivityResponse update(
+            Long userId, Long tripId, Long activityId, ActivityUpdateRequest request
+    ) {
+        validateTripMember(tripId, userId);
+
+        Activity activity = activityRepository
+                .findByIdAndTripId(activityId, tripId)
+                .orElseThrow(() -> new RuntimeException("활동을 찾을 수 없습니다."));
+
+        activity.update(request.title(), request.time());
+
+        return ActivityResponse.from(activity);
+    }
+
+    public void delete(Long userId, Long tripId, Long activityId) {
+        validateTripMember(tripId, userId);
+
+        Activity activity = activityRepository
+                .findByIdAndTripId(activityId, tripId)
+                .orElseThrow(() -> new RuntimeException("활동을 찾을 수 없습니다."));
+
+        activityRepository.delete(activity);
+    }
+
+    public ActivityResponse updateStatus(
+            Long userId, Long tripId, Long activityId, ActivityStatusUpdateRequest request
+    ) {
+        validateTripMember(tripId, userId);
+
+        Activity activity = activityRepository
+                .findByIdAndTripId(activityId, tripId)
+                .orElseThrow(() -> new RuntimeException("활동을 찾을 수 없습니다."));
+
+        activity.updateStatus(request.status());
+
+        return ActivityResponse.from(activity);
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
@@ -4,7 +4,6 @@ import gdg.travodobackend.app.travel.dto.*;
 import gdg.travodobackend.app.travel.entity.Trip;
 import gdg.travodobackend.app.travel.entity.TripMember;
 import gdg.travodobackend.app.travel.entity.TripStatus;
-import gdg.travodobackend.app.travel.repository.PersonalItemRepository;
 import gdg.travodobackend.app.travel.repository.TripMemberRepository;
 import gdg.travodobackend.app.travel.repository.TripRepository;
 import gdg.travodobackend.app.user.entity.User;
@@ -26,10 +25,13 @@ public class TripService {
     private final TripRepository tripRepository;
     private final TripMemberRepository tripMemberRepository;
     private final UserRepository userRepository;
-    private final PersonalItemRepository personalItemRepository;
 
     // 여행 생성
     public TripCreateResponse createTrip(Long userId, TripCreateRequest request) {
+
+        if (request.isDateInvalid()) {
+            throw new RuntimeException("시작 날짜는 종료 날짜보다 늦을 수 없습니다.");
+        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
@@ -62,15 +64,23 @@ public class TripService {
     }
 
     // 초대코드 재발급
-    public String regenerateInviteCode(Long tripId) {
+    public String regenerateInviteCode(Long userId, Long tripId) {
+
+        TripMember member = tripMemberRepository
+                .findByTripIdAndUserId(tripId, userId)
+                .orElseThrow(() -> new RuntimeException("여행 멤버만 초대 코드를 재발급할 수 있습니다."));
+
+        if (!member.isLeader()) {
+            throw new RuntimeException("여행 방장만 초대 코드를 재발급할 수 있습니다.");
+        }
+
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new RuntimeException("Trip not found"));
 
-        String newCode = generateUniqueInviteCode(); // 중복 방지 코드 생성
+        String newCode = generateUniqueInviteCode();
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(5);
 
-        trip.updateInviteCode(newCode,expiresAt);
-        tripRepository.save(trip);
+        trip.updateInviteCode(newCode, expiresAt);
 
         return newCode;
     }


### PR DESCRIPTION
# Travodo 여행 관리 기능 구현 및 보완 사항 정리

본 문서는 Travodo Backend의 `travel` 도메인에서 새롭게 구현한 기능과  
기존 코드에서 발견된 문제를 수정·보완한 내용을 정리한 문서입니다.

---

## 구현 기능 요약

### 1. 여행 활동(Activity) 관리 API 신규 구현

여행 중 할 활동(일정)을 관리하기 위한 Activity API를 구현했습니다.

#### Activity 구조
```json
{
  "id": 301,
  "title": "광안리 요트 투어",
  "time": "2025-12-17T15:00:00",
  "status": "PENDING"
}
```

## 초대 코드 재발급 권한 제한

- 여행을 생성한 사람(Leader)만 초대 코드를 재발급할 수 있도록 제한했습니다.
- 여행 멤버 여부 및 방장(`isLeader`) 여부를 Service 레벨에서 검증하여  
  비멤버 또는 일반 멤버의 초대 코드 재발급을 차단했습니다.

---

## PersonalItem / SharedItem Validation 보완

- 개인 준비물(PersonalItem)과 공동 준비물(SharedItem) API에서  
  `@Valid`가 적용되지 않았던 요청에 입력 검증을 추가했습니다.
- 생성(POST) 및 전체 수정 요청에 대해 DTO 기반 Validation을 적용하여  
  잘못된 입력이 저장되지 않도록 보완했습니다.

