### PR TITLE
feat/#41: 디바이스 토큰 등록 및 공동 준비물 추가 시 여행 멤버 알림 기능 구현

### DIFF
--- a/src/main/java/gdg/travodobackend/app/notification/controller/NotificationController.java
+++ b/src/main/java/gdg/travodobackend/app/notification/controller/NotificationController.java
@@ -1,0 +1,82 @@
+package gdg.travodobackend.app.notification.controller;
+
+import gdg.travodobackend.app.notification.dto.DeviceTokenRegisterRequest;
+import gdg.travodobackend.app.notification.dto.NotificationResponse;
+import gdg.travodobackend.app.notification.service.DeviceTokenService;
+import gdg.travodobackend.app.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(
+        name = "알림",
+        description = "알림 조회, 읽음 처리 및 디바이스 토큰 등록 API"
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final DeviceTokenService deviceTokenService;
+
+    @PostMapping("/device")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+            summary = "디바이스 토큰 등록",
+            description = """
+                    푸시 알림 수신을 위해 사용자의 디바이스 토큰을 등록합니다.
+                    
+                    - 로그인된 사용자만 등록 가능합니다.
+                    - 동일한 디바이스 토큰은 중복 등록되지 않습니다.
+                    - 추후 FCM 푸시 알림 전송을 위한 기반 API입니다.
+                    """
+    )
+    public void registerDeviceToken(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody DeviceTokenRegisterRequest request
+    ) {
+        deviceTokenService.register(userId, request);
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "내 알림 목록 조회",
+            description = """
+                    로그인한 사용자의 알림 목록을 최신순으로 조회합니다.
+                    
+                    - 본인에게 수신된 알림만 조회됩니다.
+                    - 읽음 여부(isRead) 정보를 함께 반환합니다.
+                    """
+    )
+    public List<NotificationResponse> getMyNotifications(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return notificationService.getMyNotifications(userId);
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(
+            summary = "알림 읽음 처리",
+            description = """
+                    특정 알림을 읽음 상태로 변경합니다.
+                    
+                    - 본인에게 수신된 알림만 읽음 처리할 수 있습니다.
+                    - 이미 읽은 알림을 다시 요청해도 문제없이 처리됩니다.
+                    - 성공 시 응답 본문 없이 204 상태 코드를 반환합니다.
+                    """
+    )
+    public void markAsRead(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long notificationId
+    ) {
+        notificationService.markAsRead(userId, notificationId);
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/notification/dto/DeviceTokenRegisterRequest.java
+++ b/src/main/java/gdg/travodobackend/app/notification/dto/DeviceTokenRegisterRequest.java
@@ -1,0 +1,14 @@
+package gdg.travodobackend.app.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class DeviceTokenRegisterRequest {
+
+    @NotBlank
+    private String deviceToken;
+
+    @NotBlank
+    private String platform;
+}

--- a/src/main/java/gdg/travodobackend/app/notification/dto/NotificationResponse.java
+++ b/src/main/java/gdg/travodobackend/app/notification/dto/NotificationResponse.java
@@ -1,0 +1,23 @@
+package gdg.travodobackend.app.notification.dto;
+
+import gdg.travodobackend.app.notification.entity.Notification;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long id,
+        String title,
+        String message,
+        Boolean isRead,
+        LocalDateTime createdAt
+) {
+    public static NotificationResponse from(Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getTitle(),
+                notification.getMessage(),
+                notification.getIsRead(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/notification/entity/DeviceToken.java
+++ b/src/main/java/gdg/travodobackend/app/notification/entity/DeviceToken.java
@@ -1,0 +1,27 @@
+package gdg.travodobackend.app.notification.entity;
+
+import gdg.travodobackend.app.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeviceToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String deviceToken;
+
+    @Column(nullable = false)
+    private String platform; // IOS / ANDROID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/gdg/travodobackend/app/notification/entity/Notification.java
+++ b/src/main/java/gdg/travodobackend/app/notification/entity/Notification.java
@@ -1,0 +1,44 @@
+package gdg.travodobackend.app.notification.entity;
+
+import gdg.travodobackend.app.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column(nullable = false)
+    private Boolean isRead;
+
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @PrePersist
+    void prePersist() {
+        this.isRead = false;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/gdg/travodobackend/app/notification/repository/DeviceTokenRepository.java
@@ -1,0 +1,12 @@
+package gdg.travodobackend.app.notification.repository;
+
+import gdg.travodobackend.app.notification.entity.DeviceToken;
+import gdg.travodobackend.app.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+
+    Optional<DeviceToken> findByUserAndDeviceToken(User user, String deviceToken);
+}

--- a/src/main/java/gdg/travodobackend/app/notification/repository/NotificationRepository.java
+++ b/src/main/java/gdg/travodobackend/app/notification/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package gdg.travodobackend.app.notification.repository;
+
+import gdg.travodobackend.app.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByReceiverIdOrderByCreatedAtDesc(Long receiverId);
+}

--- a/src/main/java/gdg/travodobackend/app/notification/service/DeviceTokenService.java
+++ b/src/main/java/gdg/travodobackend/app/notification/service/DeviceTokenService.java
@@ -1,0 +1,36 @@
+package gdg.travodobackend.app.notification.service;
+
+import gdg.travodobackend.app.notification.dto.DeviceTokenRegisterRequest;
+import gdg.travodobackend.app.notification.entity.DeviceToken;
+import gdg.travodobackend.app.notification.repository.DeviceTokenRepository;
+import gdg.travodobackend.app.user.entity.User;
+import gdg.travodobackend.app.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void register(Long userId, DeviceTokenRegisterRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+        if (deviceTokenRepository.findByUserAndDeviceToken(user, request.getDeviceToken()).isPresent()) {
+            return;
+        }
+
+        DeviceToken deviceToken = DeviceToken.builder()
+                .user(user)
+                .deviceToken(request.getDeviceToken())
+                .platform(request.getPlatform())
+                .build();
+
+        deviceTokenRepository.save(deviceToken);
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/notification/service/NotificationEmailService.java
+++ b/src/main/java/gdg/travodobackend/app/notification/service/NotificationEmailService.java
@@ -1,0 +1,26 @@
+package gdg.travodobackend.app.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationEmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendSharedItemNotificationMail(
+            String to,
+            String title,
+            String message
+    ) {
+        SimpleMailMessage mail = new SimpleMailMessage();
+        mail.setFrom("gdgoctravodo@gmail.com");
+        mail.setTo(to);
+        mail.setSubject(title);
+        mail.setText(message);
+        mailSender.send(mail);
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/notification/service/NotificationService.java
+++ b/src/main/java/gdg/travodobackend/app/notification/service/NotificationService.java
@@ -1,0 +1,79 @@
+package gdg.travodobackend.app.notification.service;
+
+import gdg.travodobackend.app.notification.dto.NotificationResponse;
+import gdg.travodobackend.app.notification.entity.Notification;
+import gdg.travodobackend.app.travel.entity.Trip;
+import gdg.travodobackend.app.travel.entity.TripMember;
+import gdg.travodobackend.app.notification.repository.NotificationRepository;
+import gdg.travodobackend.app.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationEmailService notificationEmailService;
+
+    /**
+     * 공동 준비물 추가 알림 생성
+     */
+    @Transactional
+    public void createSharedItemAddedNotification(
+            Trip trip,
+            User actor,
+            String itemName
+    ) {
+        for (TripMember member : trip.getMembers()) {
+            User receiver = member.getUser();
+
+            if (receiver.getId().equals(actor.getId())) continue;
+
+            Notification notification = Notification.builder()
+                    .receiver(receiver)
+                    .title("공동 준비물이 추가되었어요")
+                    .message("공동 준비물 '" + itemName + "' 이(가) 추가되었습니다.")
+                    .build();
+
+            notificationRepository.save(notification);
+
+            // 이메일은 실패해도 알림 생성에 영향 없음
+            try {
+                notificationEmailService.sendSharedItemNotificationMail(
+                        receiver.getEmail(),
+                        notification.getTitle(),
+                        notification.getMessage()
+                );
+            } catch (Exception e) {
+                // 로그만 남기고 무시 (정책 A)
+                log.warn("이메일 발송 실패: {}", receiver.getEmail(), e);
+            }
+        }
+    }
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getMyNotifications(Long userId) {
+        return notificationRepository
+                .findByReceiverIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(NotificationResponse::from)
+                .toList();
+        }
+
+    @Transactional
+    public void markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new IllegalArgumentException("알림이 존재하지 않습니다"));
+
+        if (!notification.getReceiver().getId().equals(userId)) {
+            throw new IllegalStateException("본인의 알림만 읽을 수 있습니다");
+        }
+
+        notification.markAsRead();
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/travel/service/SharedItemService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/SharedItemService.java
@@ -1,5 +1,6 @@
 package gdg.travodobackend.app.travel.service;
 
+import gdg.travodobackend.app.notification.service.NotificationService;
 import gdg.travodobackend.app.travel.dto.SharedItemCreateRequest;
 import gdg.travodobackend.app.travel.dto.SharedItemResponse;
 import gdg.travodobackend.app.travel.dto.SharedItemUpdateRequest;
@@ -25,6 +26,7 @@ public class SharedItemService {
     private final TripRepository tripRepository;
     private final TripMemberRepository tripMemberRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     /**
      * 여행 멤버 검증
@@ -58,6 +60,9 @@ public class SharedItemService {
         Trip trip = tripRepository.findById(tripId)
                 .orElseThrow(() -> new RuntimeException("여행을 찾을 수 없습니다."));
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
         SharedItem item = SharedItem.builder()
                 .trip(trip)
                 .name(request.name())
@@ -66,6 +71,12 @@ public class SharedItemService {
                 .build();
 
         sharedItemRepository.save(item);
+
+        notificationService.createSharedItemAddedNotification(
+                trip,
+                user,
+                item.getName()
+        );
 
         return SharedItemResponse.from(item);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,9 +8,9 @@ spring:
 
     datasource:
         driver-class-name: com.mysql.cj.jdbc.Driver
-        url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:travodo_db}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false
-        username: ${DB_USERNAME:root}
-        password: ${DB_PASSWORD:1234}
+        url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false
+        username: ${DB_USERNAME:}
+        password: ${DB_PASSWORD:}
         hikari:
             maximum-pool-size: 5
             minimum-idle: 2
@@ -34,8 +34,8 @@ spring:
     mail:
         host: smtp.gmail.com
         port: 587
-        username: ${MAIL_USERNAME:gdgoctravodo@gmail.com}
-        password: ${MAIL_PASSWORD:kvvtwqrtbeedjtaj}
+        username: ${MAIL_USERNAME:}
+        password: ${MAIL_PASSWORD:}
         properties:
             mail:
                 smtp:


### PR DESCRIPTION
## 알림(Notification) 기능 추가

공동 준비물 생성 시 여행 멤버에게 알림이 전달되도록  
알림 도메인 및 관련 API를 구현했습니다.

---

## 구현 배경

여행 중 공동 준비물이 추가되었을 때  
참여 중인 다른 멤버들이 이를 즉시 인지할 수 있도록  
알림 기능이 필요하다고 판단하여 구현을 진행했습니다.

---

## 구현 내용

### 알림 도메인(Notification) 구현
- 알림 엔티티(`Notification`) 생성
- 수신자(User), 제목, 메시지, 읽음 여부, 생성 시간 관리
- 사용자별 알림 조회 기능 제공

### 공동 준비물 생성 시 알림 자동 생성
- 공동 준비물 생성 시
  - 여행 멤버 중 **본인을 제외한 사용자**에게 알림 생성
  - 각 사용자별로 개별 알림 레코드 저장

### 이메일 알림 연동 (선택적)
- 알림 생성 시 이메일 발송 시도
- 이메일 발송 실패 시에도
  - 알림 생성 로직은 정상 동작하도록 처리
- 로그만 남기고 트랜잭션에는 영향 없음

### 알림 조회 및 읽음 처리 API
- 로그인한 사용자의 알림 목록 최신순 조회
- 개별 알림 읽음 처리 API 제공
- 본인 알림만 읽음 처리 가능하도록 검증 로직 추가

###  디바이스 토큰 등록 API
- 푸시 알림 확장을 위한 디바이스 토큰 등록 API 구현
- 동일 토큰 중복 등록 방지
- 추후 FCM 푸시 알림 연동을 고려한 구조 설계

---

## 📡 추가된 API 목록

### 알림 관련 API
| Method | Endpoint | 설명 |
|------|--------|------|
| POST | `/api/notifications/device` | 디바이스 토큰 등록 |
| GET | `/api/notifications` | 내 알림 목록 조회 |
| PATCH | `/api/notifications/{notificationId}/read` | 알림 읽음 처리 |

---

## 설계 포인트

- 알림(Notification)은 **사용자 단위로 생성**
- 읽음 여부(`isRead`)는 **개별 사용자 기준**
- 이메일 발송 실패가 전체 로직에 영향을 주지 않도록 분리
- 추후 FCM 푸시 알림 연동 시  
  기존 구조를 그대로 확장 가능하도록 설계

---

## 추후 확장 예정

- FCM 푸시 알림 연동
