### PR TITLE
feat/#44: 지도 팀원 위치 색상 고정, 동행자 위치 관리 개선

### DIFF
--- a/src/main/java/gdg/travodobackend/app/travel/dto/MapPointDto.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/MapPointDto.java
@@ -11,18 +11,21 @@ public record MapPointDto(
         String status,
 
         Double latitude,
-        Double longitude
+        Double longitude,
+
+        String color
 ) {
 
     public static MapPointDto member(
             Long memberId, String nickname,
-            Double latitude, Double longitude
+            Double latitude, Double longitude,
+            String color
     ) {
         return new MapPointDto(
                 "MEMBER",
                 memberId, nickname,
                 null, null, null,
-                latitude, longitude
+                latitude, longitude, color
         );
     }
 
@@ -34,7 +37,7 @@ public record MapPointDto(
                 "ACTIVITY",
                 null, null,
                 activityId, title, status,
-                latitude, longitude
+                latitude, longitude,null
         );
     }
 }

--- a/src/main/java/gdg/travodobackend/app/travel/dto/MemberLocationResponse.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/MemberLocationResponse.java
@@ -7,5 +7,6 @@ public record MemberLocationResponse(
         String nickname,
         double latitude,
         double longitude,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        String color
 ) {}

--- a/src/main/java/gdg/travodobackend/app/travel/entity/MapColor.java
+++ b/src/main/java/gdg/travodobackend/app/travel/entity/MapColor.java
@@ -1,0 +1,18 @@
+package gdg.travodobackend.app.travel.entity;
+
+import java.util.List;
+import java.util.Random;
+
+public class MapColor {
+
+    public static final List<String> COLORS = List.of(
+            "#EE8787", "#FFD2C2", "#EAAF4F", "#FFE386",
+            "#A4C664", "#B8CDFF", "#769FFF", "#506CAD"
+    );
+
+    private static final Random RANDOM = new Random();
+
+    public static String random() {
+        return COLORS.get(RANDOM.nextInt(COLORS.size()));
+    }
+}

--- a/src/main/java/gdg/travodobackend/app/travel/entity/TripMemberLocation.java
+++ b/src/main/java/gdg/travodobackend/app/travel/entity/TripMemberLocation.java
@@ -3,7 +3,6 @@ package gdg.travodobackend.app.travel.entity;
 import gdg.travodobackend.app.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-
 import java.time.LocalDateTime;
 
 @Entity
@@ -33,6 +32,9 @@ public class TripMemberLocation {
 
     private LocalDateTime updatedAt;
 
+    @Column(nullable = false)
+    private String color;
+
     public void update(double latitude, double longitude) {
         this.latitude = latitude;
         this.longitude = longitude;
@@ -49,5 +51,16 @@ public class TripMemberLocation {
         }
         update(latitude, longitude);
         return true;
+    }
+
+    // 최초 1회만 색상 지정
+    public void assignColorIfAbsent() {
+        if (this.color == null) {
+            this.color = MapColor.random();
+        }
+    }
+
+    public void assignColor(String color) {
+        this.color = color;
     }
 }

--- a/src/main/java/gdg/travodobackend/app/travel/repository/TripMemberLocationRepository.java
+++ b/src/main/java/gdg/travodobackend/app/travel/repository/TripMemberLocationRepository.java
@@ -4,6 +4,8 @@ import gdg.travodobackend.app.travel.entity.Trip;
 import gdg.travodobackend.app.travel.entity.TripMemberLocation;
 import gdg.travodobackend.app.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +13,7 @@ import java.util.Optional;
 public interface TripMemberLocationRepository extends JpaRepository<TripMemberLocation, Long> {
     Optional<TripMemberLocation> findByTripAndUser(Trip trip, User user);
     List<TripMemberLocation> findAllByTrip(Trip trip);
+
+    @Query("select l.color from TripMemberLocation l where l.trip = :trip")
+    List<String> findUsedColorsByTrip(@Param("trip") Trip trip);
 }

--- a/src/main/java/gdg/travodobackend/app/travel/service/TripMapService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/TripMapService.java
@@ -4,6 +4,7 @@ import gdg.travodobackend.app.travel.dto.LocationUpdateRequest;
 import gdg.travodobackend.app.travel.dto.MapPointDto;
 import gdg.travodobackend.app.travel.dto.MapPointsResponse;
 import gdg.travodobackend.app.travel.dto.MemberLocationResponse;
+import gdg.travodobackend.app.travel.entity.MapColor;
 import gdg.travodobackend.app.travel.entity.Trip;
 import gdg.travodobackend.app.travel.entity.TripMemberLocation;
 import gdg.travodobackend.app.travel.repository.ActivityRepository;
@@ -20,6 +21,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
@@ -59,6 +61,8 @@ public class TripMapService {
                         .build()
                 );
 
+        location.assignColorIfAbsent();
+
         boolean changed = location.updateIfChanged(
                 req.latitude(),
                 req.longitude()
@@ -86,7 +90,8 @@ public class TripMapService {
                         loc.getUser().getNickname(),
                         loc.getLatitude(),
                         loc.getLongitude(),
-                        loc.getUpdatedAt()
+                        loc.getUpdatedAt(),
+                        loc.getColor()
                 ))
                 .toList();
     }
@@ -115,7 +120,8 @@ public class TripMapService {
                         loc.getUser().getId(),
                         loc.getUser().getNickname(),
                         loc.getLatitude(),
-                        loc.getLongitude()
+                        loc.getLongitude(),
+                        loc.getColor()
                 ))
         );
 
@@ -140,4 +146,40 @@ public class TripMapService {
                 points
         );
     }
+
+    private String pickAvailableColor(Trip trip) {
+
+        List<String> usedColors = locationRepository.findUsedColorsByTrip(trip);
+
+        List<String> availableColors = MapColor.COLORS.stream()
+                .filter(color -> !usedColors.contains(color))
+                .toList();
+
+        if (availableColors.isEmpty()) {
+            return MapColor.random(); // fallback
+        }
+
+        return availableColors.get(
+                new Random().nextInt(availableColors.size())
+        );
+    }
+
+    @Transactional
+    public void ensureMemberLocationExists(Trip trip, User user) {
+
+        locationRepository.findByTripAndUser(trip, user)
+                .orElseGet(() -> {
+
+                    String color = pickAvailableColor(trip);
+
+                    TripMemberLocation location = TripMemberLocation.builder()
+                            .trip(trip)
+                            .user(user)
+                            .color(color)
+                            .build();
+
+                    return locationRepository.save(location);
+                });
+    }
+
 }

--- a/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
@@ -25,6 +25,7 @@ public class TripService {
     private final TripRepository tripRepository;
     private final TripMemberRepository tripMemberRepository;
     private final UserRepository userRepository;
+    private final TripMapService tripMapService;
 
     private static final List<String> TRIP_COLORS = List.of(
             "#EE8787", "#FFD2C2", "#EAAF4F", "#FFE386",
@@ -69,6 +70,7 @@ public class TripService {
                 .isLeader(true)
                 .build();
         tripMemberRepository.save(leader);
+        tripMapService.ensureMemberLocationExists(trip, user);
 
         return new TripCreateResponse(
                 TripResponse.from(trip),
@@ -127,6 +129,7 @@ public class TripService {
                 .build();
 
         tripMemberRepository.save(member);
+        tripMapService.ensureMemberLocationExists(trip, user);
 
         return TripResponse.from(trip);
     }


### PR DESCRIPTION
# 지도 팀원 위치 색상 고정 & 동행자 위치 관리 개선

## 개요
여행 지도에서 각 팀원의 위치가 **랜덤하지만 고정된 색상**으로 표시되도록 개선하고,  
**위치 업데이트를 하지 않은 팀원도 지도 데이터에 포함**되도록 백엔드 로직을 보완했습니다.

---

## 구현 목표

- 같은 여행 내 팀원들은 **중복되지 않는 랜덤 색상**을 가짐
- 한 번 부여된 색상은 **모든 사용자에게 동일하게 표시**
- 위치를 아직 업데이트하지 않은 유저도 **지도 데이터에 포함**
- 색상은 클라이언트가 아닌 **서버에서 결정 및 영속화**

---

## 백엔드 수정 사항

### 1. TripMemberLocation 엔티티 확장
- 팀원 위치에 사용할 `color` 필드 추가
- 색상은 DB에 저장되어 요청마다 변경되지 않음

## 프론트엔드 작업 사항

### 팀원 마커 색상 처리 (필수)

- 지도 마커 색상은 **API 응답의 `color` 값을 그대로 사용**
- 프론트에서 랜덤 색상 생성 ❌ (서버에서 이미 결정됨)

```ts
markerColor = member.color;

```java
@Column(nullable = false)
private String color;
