### PR TITLE
fix/#52: 초대코드 재발급 메서드 트랜젝션 추가

### DIFF
--- a/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
@@ -94,6 +94,7 @@ public class TripService {
     }
 
     // 초대코드 재발급
+    @Transactional
     public String regenerateInviteCode(Long userId, Long tripId) {
 
         TripMember member = tripMemberRepository


### PR DESCRIPTION
### 🔧 수정 사항

- 초대 코드 재발급 로직에 `@Transactional`을 추가했습니다.
- 재발급된 초대 코드와 만료 시간이 **DB에 즉시 반영(commit)** 된 이후 다음 요청에서 사용되도록 보장합니다.
- 재발급 직후 초대 코드로 여행 참여 시 발생하던 불일치 문제를 방지합니다.
