### PR TITLE
fix/#56:현재 진행중인 여행 조회 응답 구조 수정

### DIFF
--- a/src/main/java/gdg/travodobackend/app/travel/controller/TripController.java
+++ b/src/main/java/gdg/travodobackend/app/travel/controller/TripController.java
@@ -160,26 +160,13 @@ public class TripController {
 
     @Operation(
             summary = "현재 진행중인 여행 조회",
-            description = "로그인한 사용자의 현재 진행중인 여행을 조회합니다."
+            description = "로그인한 사용자의 현재 진행중인 여행을 조회합니다. 진행 중인 여행이 없으면 null을 반환합니다."
     )
     @GetMapping("/current")
-    public ResponseEntity<?> getCurrentTrip(
+    public ResponseEntity<CurrentTripResponse> getCurrentTrip(
             @AuthenticationPrincipal Long userId
     ) {
-        try {
-            return ResponseEntity.ok(
-                    Map.of("trip", tripService.getCurrentTrip(userId))
-            );
-        } catch (RuntimeException e) {
-            // 진행 중인 여행이 없는 정상 케이스
-            if ("아직 진행 중인 여행이 없습니다.".equals(e.getMessage())) {
-                return ResponseEntity
-                        .status(HttpStatus.NOT_FOUND)
-                        .body(Map.of("message", e.getMessage()));
-            }
-            // 그 외는 진짜 서버 에러
-            throw e;
-        }
+        return ResponseEntity.ok(tripService.getCurrentTripOrNull(userId));
     }
 
     @Operation(

--- a/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/TripService.java
@@ -296,6 +296,24 @@ public class TripService {
                 );
     }
 
+    @Transactional(readOnly = true)
+    public CurrentTripResponse getCurrentTripOrNull(Long userId) {
+
+        return tripMemberRepository
+                .findByUserIdAndTripStatus(userId, TripStatus.ONGOING)
+                .map(tripMember -> {
+                    Trip trip = tripMember.getTrip();
+                    return new CurrentTripResponse(
+                            trip.getId(),
+                            trip.getName(),
+                            trip.getStatus(),
+                            trip.getStartDate(),
+                            trip.getEndDate()
+                    );
+                })
+                .orElse(null);
+    }
+
     /**
      * 여행 삭제 (trip 자체 삭제)
      * - 현재 구현상 Trip과 연관된 엔티티들이 cascade remove 설정이 없으므로


### PR DESCRIPTION
## 현재 진행중인 여행 조회 API 수정

### 수정 배경
프론트엔드에서 **현재 진행중인 여행 조회 API (`GET /api/trips/current`)가 정상 동작하지 않는다**는 이슈가 제기되었습니다.  
확인 결과, 이는 **백엔드 응답 구조 및 예외 처리 방식이 프론트 기대와 달랐기 때문**입니다.

---

### 문제 원인
1. **응답 구조 불일치**
   - 기존 응답이 `{ "trip": {...} }` 형태로 반환되어  
     프론트에서 `response.data.id` 접근 시 `undefined` 발생

2. **정상 케이스를 예외로 처리**
   - 진행 중인 여행이 없는 경우에도 `RuntimeException`을 발생시키고
   - Controller에서 이를 `404 Not Found`로 변환
   - 프론트에서는 API 실패로 인식

3. **팀 규칙과의 충돌**
   - “런타임 익셉션만 사용” 규칙은 지켰으나  
     *정상 흐름*을 예외로 제어하고 있었음

---

### 수정 내용
#### Controller 수정
- `GET /api/trips/current` 응답 구조를 **단일 객체 반환**으로 변경
- try-catch 및 404 응답 제거
- 항상 `200 OK` 반환

```java
@GetMapping("/current")
public ResponseEntity<CurrentTripResponse> getCurrentTrip(
        @AuthenticationPrincipal Long userId
) {
    return ResponseEntity.ok(tripService.getCurrentTripOrNull(userId));
}
