### PR TITLE
fix/#65: 여행 활동 api 반환값 수정

### DIFF
--- a/src/main/java/gdg/travodobackend/app/travel/controller/ActivityController.java
+++ b/src/main/java/gdg/travodobackend/app/travel/controller/ActivityController.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Tag(
         name = "여행 활동",
@@ -27,30 +28,20 @@ public class ActivityController {
     private final ActivityService activityService;
 
     @Operation(
-            summary = "DAY별 여행 활동 조회",
+            summary = "여행 활동 목록 조회",
             description = """
-                특정 날짜의 여행 활동 목록을 조회합니다.
-                - 진행 중(ONGOING) 상태의 여행에서만 조회 가능합니다.
-                """
+            여행의 모든 활동(Activity)을 조회합니다.
+            - 여행 상태와 관계없이 조회 가능합니다.
+            - 날짜/시간 기준 조회는 사용하지 않습니다.
+            """
     )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "403", description = "여행 멤버가 아님"),
-            @ApiResponse(responseCode = "400", description = "진행 중인 여행이 아님"),
-            @ApiResponse(responseCode = "404", description = "여행을 찾을 수 없음")
-    })
     @GetMapping
-    public ResponseEntity<ActivityDayResponse> getActivitiesByDate(
+    public ResponseEntity<List<ActivityResponse>> getActivities(
             @AuthenticationPrincipal Long userId,
-
-            @Parameter(description = "여행 ID", example = "1")
-            @PathVariable Long tripId,
-
-            @Parameter(description = "조회 날짜 (YYYY-MM-DD)", example = "2025-12-20")
-            @RequestParam LocalDate date
+            @PathVariable Long tripId
     ) {
         return ResponseEntity.ok(
-                activityService.getActivitiesByDate(userId, tripId, date)
+                activityService.getActivities(userId, tripId)
         );
     }
 
@@ -113,15 +104,10 @@ public class ActivityController {
             @ApiResponse(responseCode = "404", description = "활동을 찾을 수 없음")
     })
     @PatchMapping("/{activityId}/status")
-    public ResponseEntity<ActivityResponse> updateStatus(
+    public ResponseEntity<Boolean> updateStatus(
             @AuthenticationPrincipal Long userId,
-
-            @Parameter(description = "여행 ID", example = "1")
             @PathVariable Long tripId,
-
-            @Parameter(description = "활동 ID", example = "10")
             @PathVariable Long activityId,
-
             @Valid @RequestBody ActivityStatusUpdateRequest request
     ) {
         return ResponseEntity.ok(

--- a/src/main/java/gdg/travodobackend/app/travel/dto/activity/ActivityCreateRequest.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/activity/ActivityCreateRequest.java
@@ -1,17 +1,10 @@
 package gdg.travodobackend.app.travel.dto.activity;
 
-import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
-import java.time.LocalDateTime;
 
 public record ActivityCreateRequest(
 
         @NotBlank(message = "활동 제목은 필수입니다.")
-        String title,
+        String title
 
-        @NotNull(message = "활동 시간은 필수입니다.")
-        @Future(message = "활동 시간은 미래여야 합니다.")
-        LocalDateTime time
 ) {}

--- a/src/main/java/gdg/travodobackend/app/travel/dto/activity/ActivityResponse.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/activity/ActivityResponse.java
@@ -7,14 +7,12 @@ import java.time.LocalDateTime;
 public record ActivityResponse(
         Long id,
         String title,
-        LocalDateTime time,
         String status
 ) {
     public static ActivityResponse from(Activity activity) {
         return new ActivityResponse(
                 activity.getId(),
                 activity.getTitle(),
-                activity.getTime(),
                 activity.getStatus().name()
         );
     }

--- a/src/main/java/gdg/travodobackend/app/travel/dto/activity/ActivityUpdateRequest.java
+++ b/src/main/java/gdg/travodobackend/app/travel/dto/activity/ActivityUpdateRequest.java
@@ -1,17 +1,10 @@
 package gdg.travodobackend.app.travel.dto.activity;
 
-import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
-import java.time.LocalDateTime;
 
 public record ActivityUpdateRequest(
 
         @NotBlank(message = "활동 제목은 필수입니다.")
-        String title,
+        String title
 
-        @NotNull(message = "활동 시간은 필수입니다.")
-        @Future(message = "활동 시간은 미래여야 합니다.")
-        LocalDateTime time
 ) {}

--- a/src/main/java/gdg/travodobackend/app/travel/entity/Activity.java
+++ b/src/main/java/gdg/travodobackend/app/travel/entity/Activity.java
@@ -25,9 +25,8 @@ public class Activity {
     @Enumerated(EnumType.STRING)
     private ActivityStatus status;
 
-    public void update(String title, LocalDateTime time) {
+    public void update(String title) {
         this.title = title;
-        this.time = time;
     }
 
     public void updateStatus(ActivityStatus status) {

--- a/src/main/java/gdg/travodobackend/app/travel/repository/ActivityRepository.java
+++ b/src/main/java/gdg/travodobackend/app/travel/repository/ActivityRepository.java
@@ -16,6 +16,7 @@ public interface ActivityRepository extends JpaRepository<Activity, Long> {
             LocalDateTime start,
             LocalDateTime end
     );
+    List<Activity> findAllByTripId(Long tripId);
 
     void deleteByTripId(Long tripId);
 }

--- a/src/main/java/gdg/travodobackend/app/travel/service/ActivityService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/ActivityService.java
@@ -37,7 +37,6 @@ public class ActivityService {
         Activity activity = Activity.builder()
                 .trip(trip)
                 .title(request.title())
-                .time(request.time())
                 .status(ActivityStatus.PENDING)
                 .build();
 
@@ -55,7 +54,7 @@ public class ActivityService {
                 .findByIdAndTripId(activityId, tripId)
                 .orElseThrow(() -> new RuntimeException("활동을 찾을 수 없습니다."));
 
-        activity.update(request.title(), request.time());
+        activity.update(request.title());
 
         return ActivityResponse.from(activity);
     }
@@ -70,7 +69,7 @@ public class ActivityService {
         activityRepository.delete(activity);
     }
 
-    public ActivityResponse updateStatus(
+    public boolean updateStatus(
             Long userId, Long tripId, Long activityId, ActivityStatusUpdateRequest request
     ) {
         validateTripMember(tripId, userId);
@@ -81,36 +80,18 @@ public class ActivityService {
 
         activity.updateStatus(request.status());
 
-        return ActivityResponse.from(activity);
+        return true;
     }
 
     @Transactional(readOnly = true)
-    public ActivityDayResponse getActivitiesByDate(
-            Long userId, Long tripId, LocalDate date
+    public List<ActivityResponse> getActivities(
+            Long userId, Long tripId
     ) {
         validateTripMember(tripId, userId);
 
-        Trip trip = tripRepository.findById(tripId)
-                .orElseThrow(() -> new RuntimeException("여행을 찾을 수 없습니다."));
-
-        if (trip.getStatus() != TripStatus.ONGOING) {
-            throw new RuntimeException("진행 중인 여행에서만 오늘 일정을 조회할 수 있습니다.");
-        }
-
-        LocalDateTime start = date.atStartOfDay();
-        LocalDateTime end = date.atTime(23, 59, 59);
-
-        List<ActivityResponse> activities = activityRepository
-                .findAllByTripIdAndTimeBetween(tripId, start, end)
+        return activityRepository.findAllByTripId(tripId)
                 .stream()
                 .map(ActivityResponse::from)
                 .toList();
-
-        return new ActivityDayResponse(
-                tripId,
-                date.toString(),
-                activities
-        );
     }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,9 +8,9 @@ spring:
 
     datasource:
         driver-class-name: com.mysql.cj.jdbc.Driver
-        url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:travodo_db}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false
-        username: ${DB_USERNAME:root}
-        password: ${DB_PASSWORD:1234}
+        url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&useSSL=false
+        username: ${DB_USERNAME:}
+        password: ${DB_PASSWORD:}
         hikari:
             maximum-pool-size: 5
             minimum-idle: 2
@@ -43,8 +43,8 @@ spring:
     mail:
         host: smtp.gmail.com
         port: 587
-        username: ${MAIL_USERNAME:gdgoctravodo@gmail.com}
-        password: ${MAIL_PASSWORD:kvvtwqrtbeedjtaj}
+        username: ${MAIL_USERNAME:}
+        password: ${MAIL_PASSWORD:}
         properties:
             mail:
                 smtp:


### PR DESCRIPTION
## 여행 활동(Activity) API 구조 개선

### 변경 배경
- preTrip / onTrip 화면에서는 날짜·시간을 지정하지 않고 활동을 추가하는 UX를 사용
- 기존 Activity API는 날짜·시간 필수 및 진행 중(ONGOING) 여행에서만 조회 가능하여 프론트 연동 불가
- Activity를 **여행 단위 Todo/체크리스트**로 활용하기 위해 구조 단순화 필요

---

### 주요 변경 사항

#### Activity 생성 / 수정 시 시간(time) 제거
- Activity를 날짜·시간에 구속받지 않는 Todo 개념으로 사용
- `ActivityCreateRequest`, `ActivityUpdateRequest`에서 `time` 필드 제거
- title만으로 활동 생성 및 수정 가능

#### Activity 조회 API 단순화
- 날짜(date) 파라미터 제거
- 여행 상태(PRE / ONGOING)와 관계없이 조회 가능하도록 변경
- `GET /api/trips/{tripId}/activities` → 여행의 전체 활동 목록 반환

#### 여행 상태 제한 제거
- 기존 ONGOING 상태에서만 조회 가능하던 제약 제거
- 여행 전(preTrip)에도 활동 추가 및 조회 가능

#### 활동 상태 변경 API 응답 변경
- 상태 변경 API의 반환 타입을 `ActivityResponse` → `boolean`으로 변경
- 성공 시 `true` 반환
- 체크리스트 토글 UX에 맞는 command 성격 API로 정리

---

### 세부 변경 내용

- `ActivityCreateRequest`
  - `time` 필드 제거
- `ActivityUpdateRequest`
  - `time` 필드 제거
- `ActivityResponse`
  - `time` 필드 제거
- `ActivityController`
  - 날짜 기반 조회 API 제거
  - 상태 변경 API 반환값 boolean으로 변경
- `ActivityService`
  - 날짜/시간 기반 조회 로직 제거
  - 여행 상태(ONGOING) 검증 로직 제거
- `ActivityRepository`
  - `findAllByTripId()` 메서드 추가

---

### 변경 결과
- 프론트 UI 변경 최소화
- Activity를 Todo/체크리스트처럼 자유롭게 사용 가능
- preTrip / onTrip 공통 사용 가능
- 추후 날짜 기반 일정 확장 여지 유지
