### PR TITLE
fix/#67: TripService 파라미터 오류 수정

### DIFF
--- a/src/main/java/gdg/travodobackend/app/travel/service/TodoService.java
+++ b/src/main/java/gdg/travodobackend/app/travel/service/TodoService.java
@@ -81,7 +81,7 @@ public class TodoService {
     }
 
     public TodoResponse assignTodo(Long userId, Long tripId, Long todoId) {
-        validateTripMember(userId, tripId);
+        validateTripMember(tripId, userId);
 
         Todo todo = todoRepository
                 .findByIdAndTripId(todoId, tripId)
@@ -100,7 +100,7 @@ public class TodoService {
     }
 
     public TodoResponse unassignTodo(Long userId, Long tripId, Long todoId) {
-        validateTripMember(userId, tripId);
+        validateTripMember(tripId, userId);
 
         Todo todo = todoRepository
                 .findByIdAndTripId(todoId, tripId)
@@ -120,7 +120,7 @@ public class TodoService {
     }
 
     public void deleteTodo(Long userId, Long tripId, Long todoId) {
-        validateTripMember(userId, tripId);
+        validateTripMember(tripId, userId);
 
         Todo todo = todoRepository
                 .findByIdAndTripId(todoId, tripId)


### PR DESCRIPTION
## Todo / Activity API 수정 사항 정리

### 수정 배경
- 프론트 연동 중 Todo 담당자 지정, 삭제 API 호출 시 500 에러 발생
- Activity API는 날짜·시간 제약으로 인해 preTrip / onTrip 화면에서 사용 불가
- 두 API 모두 프론트 UX에 맞게 구조 정리가 필요했음

---

## Todo API 수정 사항

### Todo 담당자 지정 / 해제 / 삭제 500 에러 수정
- 원인: `validateTripMember(tripId, userId)` 메서드 호출 시 **파라미터 순서 오류**
- 잘못된 호출
  ```java
  validateTripMember(userId, tripId);

- 수정후
  validateTripMember(tripId, userId);
